### PR TITLE
Add twigAutoescape config setting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
 				"lineageMatchKey": 2,
 				"patternExtension": "twig",
 				"twigDebug": false,
+				"twigAutoescape": "html",
 				"twigDefaultDateFormat": "",
 				"twigDefaultIntervalFormat": "",
 				"twigMacroExt": "macro.twig",

--- a/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
@@ -28,6 +28,7 @@ class PatternLoader extends Loader {
 		
 		// set-up default vars
 		$twigDebug            = Config::getOption("twigDebug");
+		$twigAutoescape       = Config::getOption("twigAutoescape");
 		
 		// set-up the loader list
 		$loaders              = array();
@@ -56,7 +57,7 @@ class PatternLoader extends Loader {
 		
 		// set-up Twig
 		$twigLoader           = new \Twig_Loader_Chain($loaders);
-		$this->instance       = new \Twig_Environment($twigLoader, array("debug" => $twigDebug));
+		$this->instance       = new \Twig_Environment($twigLoader, array("debug" => $twigDebug, "autoescape" => $twigAutoescape));
 		
 		// customize Twig
 		$this->instance       = TwigUtil::loadFilters($this->instance);


### PR DESCRIPTION
To make Pattern Lab compatible with Drupal templates. For more information please see http://www.aleksip.net/making-pattern-lab-work-with-drupal-8-twig-theme-templates

Also resolves issue #9 