### PR TITLE
adding namespaces to top level folders (i.e. @atoms)

### DIFF
--- a/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
@@ -70,17 +70,17 @@ class PatternLoader extends Loader {
 			$twigFileLoader = new \Twig_Loader_Filesystem($filesystemLoaderPaths);
 
 			// registering each directory under `_patterns/` as a namespace
-      $finder = new Finder();
-      // get all directories immediately under `_patterns/` (i.e. 00-atoms, 01-molecules, etc)
-      $finder->directories()->depth(0)->in($patternSourceDir);
-      foreach ($finder as $file) {
-        $itemPath = $file->getPathName();
-        $itemName = $file->getRelativePathName();
-        // removing any numbers followed by dashes (i.e. `00-atoms` => `atoms`)
-        $itemNamespace = preg_replace("/^\\d*-/uim", "", $itemName);
-        // registering each foldername as a namespace (i.e. can use `{% include "@atoms/forms/submit.twig" %}`)
-        $twigFileLoader->addPath($itemPath, $itemNamespace);
-      }
+			$finder = new Finder();
+			// get all directories immediately under `_patterns/` (i.e. 00-atoms, 01-molecules, etc)
+			$finder->directories()->depth(0)->in($patternSourceDir);
+			foreach ($finder as $file) {
+				$itemPath = $file->getPathName();
+				$itemName = $file->getRelativePathName();
+				// removing any numbers followed by dashes (i.e. `00-atoms` => `atoms`)
+				$itemNamespace = preg_replace("/^\\d*-/uim", "", $itemName);
+				// registering each foldername as a namespace (i.e. can use `{% include "@atoms/forms/submit.twig" %}`)
+				$twigFileLoader->addPath($itemPath, $itemNamespace);
+			}
 
 			$loaders[] = $twigFileLoader;
 		}

--- a/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
@@ -19,6 +19,7 @@ use \PatternLab\PatternEngine\Twig\Loaders\Twig\PatternPartialLoader as Twig_Loa
 use \PatternLab\PatternEngine\Twig\Loaders\Twig\PatternStringLoader as Twig_Loader_PatternStringLoader;
 use \PatternLab\PatternEngine\Loader;
 use \PatternLab\PatternEngine\Twig\TwigUtil;
+use \Symfony\Component\Finder\Finder;
 
 class PatternLoader extends Loader {
 	
@@ -66,7 +67,22 @@ class PatternLoader extends Loader {
 
 		// add the paths to the filesystem loader if the paths existed
 		if (count($filesystemLoaderPaths) > 0) {
-			$loaders[]        = new \Twig_Loader_Filesystem($filesystemLoaderPaths);
+			$twigFileLoader = new \Twig_Loader_Filesystem($filesystemLoaderPaths);
+
+			// registering each directory under `_patterns/` as a namespace
+      $finder = new Finder();
+      // get all directories immediately under `_patterns/` (i.e. 00-atoms, 01-molecules, etc)
+      $finder->directories()->depth(0)->in($patternSourceDir);
+      foreach ($finder as $file) {
+        $itemPath = $file->getPathName();
+        $itemName = $file->getRelativePathName();
+        // removing any numbers followed by dashes (i.e. `00-atoms` => `atoms`)
+        $itemNamespace = preg_replace("/^\\d*-/uim", "", $itemName);
+        // registering each foldername as a namespace (i.e. can use `{% include "@atoms/forms/submit.twig" %}`)
+        $twigFileLoader->addPath($itemPath, $itemNamespace);
+      }
+
+			$loaders[] = $twigFileLoader;
 		}
 		
 		$loaders[]            = new \Twig_Loader_String();


### PR DESCRIPTION
Adding this would let PL use [Twig Namespaces](http://twig.sensiolabs.org/doc/api.html#built-in-loaders) (i.e. `{% include "@atoms/forms/submit.twig" %}` ) for templates as an alternative to the Pattern Partial Syntax (`{% include "atoms-submit" %}`). The reason behind this is that we are able to register namespaces in other systems (like Drupal using the [components](https://www.drupal.org/project/components) module) and then have both systems digest the same templates.

This change would register a namespace for each top level folder under `source/_patterns/`. Assuming the classic top levels folders of atoms, molecules, etc were used; this would create the following namespaces, essentially little "shortcuts" to each directory:

- `@atoms` => `source/_patterns/00-atoms/`
- `@molecules` => `source/_patterns/01-molecules/`
- `@organisms` => `source/_patterns/02-organisms/`
- `@templates` => `source/_patterns/03-templates/`
- `@pages` => `source/_patterns/04-pages/`

Assuming I had this folder structure:

- 00-atoms/
    - forms/
        - text.twig
        - submit.twig

I could then include it with `{% include "@atoms/forms/submit.twig" %}`. THAT WOULD BE AWESOME!

Could we get this in? Anything I need to change? THANKS!!!