### PR TITLE
Fixing patternTypePath assignment - Undefined variable: pattern in TwigUtil.php on line 65

### DIFF
--- a/src/PatternLab/PatternEngine/Twig/TwigUtil.php
+++ b/src/PatternLab/PatternEngine/Twig/TwigUtil.php
@@ -61,7 +61,8 @@ class TwigUtil {
 		$finder = new Finder();
 		$finder->directories()->depth(0)->in($patternSourceDir);
 		foreach ($finder as $file) {
-			$patternBits = explode("-",$file->getRelativePathName(),2);
+			$pattern = $file->getRelativePathName();
+			$patternBits = explode("-",$pattern,2);
 			$patternTypePath = (((int)$patternBits[0] != 0) || ($patternBits[0] == '00')) ? $patternBits[1] : $pattern;
 			$filesystemLoader->addPath($file->getPathName(), $patternTypePath);
 		}


### PR DESCRIPTION
If you do not prefix _pattern folders with numbers and dash (00-atoms, 01-molecules) and instead use simply "atoms" and "molecules", the patternTypePath would not get assigned properly as the "else" condition of the ternary logic uses an undefined $pattern variable.

This PR fixes this issue... and will stop the following notice:

```bash
php core/console --generate
configuring pattern lab...
PHP Notice:  Undefined variable: pattern in /Users/wadeb/Sites/patterlab-demo/bw-twig-drupal/vendor/pattern-lab/patternengine-twig/src/PatternLab/PatternEngine/Twig/TwigUtil.php on line 65
```