### PR TITLE
Adds event "twigLoaderPreInit.customize" 

### DIFF
--- a/src/PatternLab/PatternEngine/Twig/TwigUtil.php
+++ b/src/PatternLab/PatternEngine/Twig/TwigUtil.php
@@ -19,7 +19,8 @@ use \Symfony\Component\Finder\Finder;
 class TwigUtil {
 	
 	protected static $instance = '';
-	
+	protected static $loaders = array();
+
 	/**
 	* Get an instance of the Twig environment
 	*
@@ -46,7 +47,46 @@ class TwigUtil {
 		}
 		
 		self::$instance = $instance;
-		
+
+	}
+
+	/**
+	* Get an instance of the Twig loaders
+	*
+	* @return {Array}       List of Twig Loaders
+	*/
+	public static function getLoaders() {
+
+		if (empty(self::$loaders)) {
+			return false;
+		}
+
+		return self::$loaders;
+
+	}
+
+	/**
+	* Set an instance of the Twig loaders
+	* @param  {Array}       List of Twig Loaders
+	*/
+	public static function setLoaders($loaders = array()) {
+
+		if (empty($loaders)) {
+			Console::writeError("please set the loaders");
+		}
+
+		self::$loaders = $loaders;
+
+	}
+
+	/**
+	* Add a loader to the Twig Loaders array
+	* @param  {Loader}       A Twig Loader
+	*/
+	public static function addLoader($loader) {
+
+		self::$loaders[] = $loader;
+
 	}
 	
 	/**


### PR DESCRIPTION
This allows plugins to manipulate the loaders list before the Twig Environment is initialized. There already is an event after initialization that allows one to change many things with the Twig Environment, however the problem I came across was when one tried to add more loaders. Turns out that [no loader can go after `Twig_Loader_String`](https://github.com/symfony/symfony/issues/10865) as that loader will interpret **anything** as a template and try to render it, so no loader can come after it. That is used by core for the rendering of the header and footer. It also is responsible for the mis-typed twig paths to simply output something like this:

    @molecules/path/to/file.twig

I'd like to get that fixed as that's a silent error, but that's another issue for another day.