### PR TITLE
Throwing error on uncompiled templates

### DIFF
--- a/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
@@ -116,7 +116,16 @@ class PatternLoader extends Loader {
 	*/
 	public function render($options = array()) {
 		
-		return $this->instance->render($options["pattern"], $options["data"]);
+		$result = $this->instance->render($options["pattern"], $options["data"]);
+		// This error handler catches files that didn't render using any of the loaders.
+		// The most common scenario is when a file's contents get passed to and through `Twig_Loader_String` and
+		// outputs the raw Twig file contents like `@atoms/buttons/button.twig`.
+		// @todo Remove this once `Twig_Loader_String` is removed.
+		if (strpos($result, "@") === 0) {
+			throw new \Twig_Error_Loader("Twig file not found: " . $result . "\n");
+		} else {
+			return $result;
+		}
 		
 	}
 	


### PR DESCRIPTION
When a Twig template contains a namespace powered path like `{% include "@atoms/buttons/button.twig" %}` and the file is not present, then there is no error thrown currently and the outputted Pattern simply contains this:

![2016-10-12 at 2 29 pm](https://cloud.githubusercontent.com/assets/569699/19328392/4388b55a-9088-11e6-8ed9-94ed30e92f03.png)

Silent errors are the worst. This is caused by `Twig_Loader_String` being the last Twig Loader in the `Twig_Loader_Chain` and will [try to render anything thrown at it](https://github.com/symfony/symfony/issues/10865) and is simply doing that above. This PR ensures that if any rendered result starts with `@`, then an error is thrown. I consider it a stopgap until `Twig_Loader_Chain` is removed as it is currently deprecated and even contains the internal note to "NEVER use".