### PR TITLE
Token-like patterns no longer treated as templates

### DIFF
--- a/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
@@ -84,7 +84,7 @@ class PatternLoader extends Loader {
 		// 3. add String loader
 		// This *must* go last or no loaders after will work ~ https://github.com/symfony/symfony/issues/10865
 		// @todo Remove `Twig_Loader_String` - if a Twig include path is wrong, this outputs the string anyway with no error ~ https://github.com/symfony/symfony/issues/10865
-		$loaders[] = new \Twig_Loader_String();
+		$loaders[] = new Twig\ConditionalStringLoader();
 		
 		// set-up Twig
 		$twigLoader = new \Twig_Loader_Chain($loaders);

--- a/src/PatternLab/PatternEngine/Twig/Loaders/StringLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/StringLoader.php
@@ -48,7 +48,7 @@ class StringLoader extends Loader {
 		if (count($filesystemLoaderPaths) > 0) {
 			$loaders[] = new \Twig_Loader_Filesystem($filesystemLoaderPaths);
 		}
-		$loaders[] = new \Twig_Loader_String();
+		$loaders[] = new Twig\ConditionalStringLoader();
 		
 		// set-up Twig
 		$twigLoader = new \Twig_Loader_Chain($loaders);

--- a/src/PatternLab/PatternEngine/Twig/Loaders/Twig/ConditionalStringLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/Twig/ConditionalStringLoader.php
@@ -1,0 +1,31 @@
+<?php
+
+/*!
+ * Copyright (c) 2016 Erik Mogensen
+ * Licensed under the MIT license
+ */
+
+namespace PatternLab\PatternEngine\Twig\Loaders\Twig;
+
+class ConditionalStringLoader extends \Twig_Loader_String {
+
+	/**
+	 * Return the source context if and only if it exists.
+	 */
+	public function getSourceContext($name) {
+		if ($this->exists($name)) {
+			 return parent::getSourceContext($name);
+		}
+		return null;
+	}
+
+	/**
+	 * Return false if $name looks like a simple file name, true otherwise.
+	 *
+	 * A simple file name is a simple string consisting of alphanumerics,
+	 * periods, hyphens, underbars, and so on,  otherwise
+	 */
+	public function exists($name) {
+		return preg_match("/^[-a-zA-Z0-9~\\.\\/_@]+$/", $name) === 0;
+	}
+}


### PR DESCRIPTION
If you have templates that have typos in their includes, the use of the
Twig_Loader_String causes the typo to be echoed out:

    {% include "foo" %}

results in the string "foo" to be printed out unless "foo" is a twig
template.

This change causes "foo" to no longer be printed out, but template
generation to fail, because "foo" is not present.

This change also allows more of the twig features to be used, such as
conditional includes and dynamic includes:

    {% set foo = "something" %}

    {% include [ foo, "fallback" ] %}

Before this change, the string "something" would always be printed.
After the change, either the template "something" is included,
otherwise, the template "fallback" is included, or else an error is
raised:

    Twig_Error_Loader: Unable to find one of the following templates:
    "something", "fallback"