### PR TITLE
Mega PR: Merging Drupal Pattern Lab's Twig Pattern Engine Fork Back Into the Main Pattern Lab PHP Twig Pattern Engine Repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
 		}
 	],
 	"support": {
-		"issues":         "https://github.com/pattern-lab/patternengine-php-twig/issues",
+		"issues":         "https://github.com/drupal-pattern-lab/patternengine-php-twig/issues",
 		"wiki":           "http://patternlab.io/docs/",
-		"source":         "https://github.com/pattern-lab/patternengine-php-twig/releases"
+		"source":         "https://github.com/drupal-pattern-lab/patternengine-php-twig/releases"
 	},
 	"autoload": {
 		"psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-	"name":             "pattern-lab/patternengine-twig",
+	"name":             "drupal-pattern-lab/patternengine-twig",
 	"description":      "Twig-based PatternEngine for Pattern Lab.",
 	"keywords":         ["twig", "pattern lab", "pattern engine"],
-	"homepage":         "http://patternlab.io",
+	"homepage":         "http://drupal-pattern-lab.github.io",
 	"license":          "MIT",
 	"type":             "patternlab-patternengine",
 	"authors": [
@@ -14,9 +14,8 @@
 		}
 	],
 	"support": {
-		"issues":         "https://github.com/pattern-lab/patternengine-php-twig/issues",
-		"wiki":           "http://patternlab.io/docs/",
-		"source":         "https://github.com/pattern-lab/patternengine-php-twig/releases"
+		"issues":         "https://github.com/drupal-pattern-lab/patternengine-php-twig/issues",
+		"source":         "https://github.com/drupal-pattern-lab/patternengine-php-twig/releases"
 	},
 	"autoload": {
 		"psr-0": {
@@ -24,7 +23,7 @@
 		}
 	},
 	"require": {
-		"pattern-lab/core": "^2.0.0",
+		"drupal-pattern-lab/core": "^2.0.0",
 		"twig/twig":        "~1.0"
 	},
 	"extra": {

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-	"name":             "drupal-pattern-lab/patternengine-twig",
+	"name":             "pattern-lab/patternengine-twig",
 	"description":      "Twig-based PatternEngine for Pattern Lab.",
 	"keywords":         ["twig", "pattern lab", "pattern engine"],
-	"homepage":         "http://drupal-pattern-lab.github.io",
+	"homepage":         "http://patternlab.io",
 	"license":          "MIT",
 	"type":             "patternlab-patternengine",
 	"authors": [
@@ -14,8 +14,9 @@
 		}
 	],
 	"support": {
-		"issues":         "https://github.com/drupal-pattern-lab/patternengine-php-twig/issues",
-		"source":         "https://github.com/drupal-pattern-lab/patternengine-php-twig/releases"
+		"issues":         "https://github.com/pattern-lab/patternengine-php-twig/issues",
+		"wiki":           "http://patternlab.io/docs/",
+		"source":         "https://github.com/pattern-lab/patternengine-php-twig/releases"
 	},
 	"autoload": {
 		"psr-0": {
@@ -23,7 +24,7 @@
 		}
 	},
 	"require": {
-		"drupal-pattern-lab/core": "^2.0.0",
+		"pattern-lab/core": "^2.0.0",
 		"twig/twig":        "~1.0"
 	},
 	"extra": {


### PR DESCRIPTION
This folds in the past 5 months worth of maintenance and enhancement updates made to the Drupal Pattern Lab working group's ongoing Pattern Lab PHP Core and Pattern Lab Twig Engine (this repo) forks as part of the new exciting updates @bradfrost posted about earlier this week!

## Changelog:
- FIX: Fix long broken lineage functionality when using Twig namespaces (ie. Drupal 8 friendly paths) + picks up extends and embeds as lineages as well. Closes out #105 and related to the #129 Mega Issue | @sghoweri and @aleksip
- CHORE: Merge Pattern Lab Twig Engine dev work @dmolsen helped with back in May of 2016 | @dmolsen, @EvanLovely and @sghoweri

## TODOs
- [  ] remove references to Drupal Pattern Lab in composer.json
- [  ] move existing PRs / Issues over to main Pattern Engine PHP Twig repo