### PR TITLE
Add "Globals" Twig Extension Support

### DIFF
--- a/src/PatternLab/PatternEngine/Twig/Loaders/FilesystemLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/FilesystemLoader.php
@@ -52,6 +52,7 @@ class FilesystemLoader extends Loader {
 		TwigUtil::setInstance($instance);
 		TwigUtil::loadFilters();
 		TwigUtil::loadFunctions();
+		TwigUtil::loadGlobals();
 		TwigUtil::loadTags();
 		TwigUtil::loadTests();
 		TwigUtil::loadDateFormats();

--- a/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
@@ -94,6 +94,7 @@ class PatternLoader extends Loader {
 		TwigUtil::setInstance($instance);
 		TwigUtil::loadFilters();
 		TwigUtil::loadFunctions();
+		TwigUtil::loadGlobals();
 		TwigUtil::loadTags();
 		TwigUtil::loadTests();
 		TwigUtil::loadDateFormats();

--- a/src/PatternLab/PatternEngine/Twig/Loaders/StringLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/StringLoader.php
@@ -58,6 +58,7 @@ class StringLoader extends Loader {
 		TwigUtil::setInstance($instance);
 		TwigUtil::loadFilters();
 		TwigUtil::loadFunctions();
+		TwigUtil::loadGlobals();
 		TwigUtil::loadTags();
 		TwigUtil::loadTests();
 		TwigUtil::loadDateFormats();

--- a/src/PatternLab/PatternEngine/Twig/TwigUtil.php
+++ b/src/PatternLab/PatternEngine/Twig/TwigUtil.php
@@ -244,7 +244,51 @@ class TwigUtil {
 		}
 		
 	}
-	
+
+
+	/**
+	* Load Twig Globals for the Twig PatternEngine
+	*/
+	public static function loadGlobals() {
+
+		// load defaults
+		$globalDir = Config::getOption("sourceDir").DIRECTORY_SEPARATOR."_twig-components/globals";
+		$globalExt = Config::getOption("twigGlobalExt");
+		$globalExt = $globalExt ? $globalExt : "global.php";
+
+		if (is_dir($globalDir)) {
+
+			// loop through the global dir...
+			$finder = new Finder();
+			$finder->files()->name("*\.".$globalExt)->in($globalDir);
+			$finder->sortByName();
+			foreach ($finder as $file) {
+
+				// see if the file should be ignored or not
+				$baseName = $file->getBasename();
+				if ($baseName[0] != "_") {
+
+					include_once($file->getPathname());
+
+					$twigExtensionName = 'Twig_Extension_' . $file->getBasename('.' . $globalExt);
+					$twigExtensionName = str_replace('-', '_', $twigExtensionName); //Replace dashes with underscores for Class name
+
+					$extension = new $twigExtensionName('xyz');
+					$globals = $extension->getGlobals();
+
+					if (isset($globals)) {
+						// If global Twig values exist, loop through and add to Pattern Lab
+						foreach ($globals as $name => $value) {
+							self::$instance->addGlobal($name, $value);
+						}
+						unset($globals);
+					}
+				}
+			}
+		}
+	}
+
+
 	/**
 	* Load tags for the Twig PatternEngine
 	*/


### PR DESCRIPTION
https://twig.symfony.com/doc/2.x/advanced.html#id1

This update will continue to unlock even more interesting options for us in cross-platform Design System interoperability -- especially with things like shared Design Tokens, schema data, default inherited properties (*cough* Drupal Attributes *cough*), and more. Addresses #46

Example of this being used out in the wild (ex. sharing the default responsive img srcset breakpoint sizes): https://github.com/bolt-design-system/bolt/blob/develop/packages/bolt-twig-extensions/globals/bolt-image-sizes.global.php

CC @aleksip @bradfrost 

**Side question / point of interest:**
Note that this extension, unlike the other Twig extension integrations in Pattern Lab, doesn't require us to use some `$function = new Twig_SimpleFunction('NAME', function ($params) { ... });` wrapper -- potentially allowing opening the door for other [Twig functions](https://twig.symfony.com/doc/2.x/advanced.html#id2), [filters](https://twig.symfony.com/doc/2.x/advanced.html#id3), [tags](https://twig.symfony.com/doc/2.x/advanced.html#id4), tests and operators to get added in the same manner (ie. the same extension getting used in another environment supporting Twig could perhaps just get dropped in verbatim)