### PR TITLE
Add twigEnvironmentClass config to allow custom Twig environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,9 @@ twigExtensions:
 What happens under the hood is basically this:
 
 ```php
-$twig = new Twig_Environment($loader);
+// The $twigEnvironmentClass variable is set by the "twigEnvironmentClass" config value.
+// Defaults to \Twig_Environment.
+$twig = new $twigEnvironmentClass($loader);
 
 foreach ($twigExtensions as $twigExtension) {
     $twig->addExtension(new $twigExtension());

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
 				"twigAutoescape": "html",
 				"twigDefaultDateFormat": "",
 				"twigDefaultIntervalFormat": "",
+				"twigEnvironmentClass": "\\Twig_Environment",
 				"twigMacroExt": "macro.twig",
 				"twigFilterExt": "filter.php",
 				"twigFunctionExt": "function.php",

--- a/src/PatternLab/PatternEngine/Twig/Loaders/FilesystemLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/FilesystemLoader.php
@@ -45,8 +45,9 @@ class FilesystemLoader extends Loader {
 		}
 		
 		// set-up Twig
+		$twigEnvironmentClass = Config::getOption("twigEnvironmentClass");
 		$twigLoader = new \Twig_Loader_Filesystem($filesystemLoaderPaths);
-		$instance   = new \Twig_Environment($twigLoader, array("debug" => $twigDebug));
+		$instance   = new $twigEnvironmentClass($twigLoader, array("debug" => $twigDebug));
 		
 		// customize Twig
 		TwigUtil::setInstance($instance);

--- a/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
@@ -87,8 +87,9 @@ class PatternLoader extends Loader {
 		$loaders[] = new \Twig_Loader_String();
 		
 		// set-up Twig
+		$twigEnvironmentClass = Config::getOption("twigEnvironmentClass");
 		$twigLoader = new \Twig_Loader_Chain($loaders);
-		$instance   = new \Twig_Environment($twigLoader, array("debug" => $twigDebug, "autoescape" => $twigAutoescape));
+		$instance   = new $twigEnvironmentClass($twigLoader, array("debug" => $twigDebug, "autoescape" => $twigAutoescape));
 		
 		// customize Twig
 		TwigUtil::setInstance($instance);

--- a/src/PatternLab/PatternEngine/Twig/Loaders/StringLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/StringLoader.php
@@ -51,8 +51,9 @@ class StringLoader extends Loader {
 		$loaders[] = new \Twig_Loader_String();
 		
 		// set-up Twig
+		$twigEnvironmentClass = Config::getOption("twigEnvironmentClass");
 		$twigLoader = new \Twig_Loader_Chain($loaders);
-		$instance   = new \Twig_Environment($twigLoader, array("debug" => $twigDebug));
+		$instance   = new $twigEnvironmentClass($twigLoader, array("debug" => $twigDebug));
 		
 		// customize Twig
 		TwigUtil::setInstance($instance);


### PR DESCRIPTION
During the development of https://www.drupal.org/project/drupal/issues/3064854, it became clear that Pattern Lab will need a way to allow a plugin such as https://github.com/pattern-lab/plugin-drupal-twig-components to specify a custom Twig environment to allow for certain functionality to be added.