### PR TITLE
Use patternSourceDir

### DIFF
--- a/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
@@ -47,7 +47,7 @@ class PatternLoader extends Loader {
 		}
 
 		// add source/_patterns subdirectories for Drupal theme template compatibility
-		$patternSourceDir = Config::getOption("sourceDir").DIRECTORY_SEPARATOR."_patterns";
+		$patternSourceDir = Config::getOption("patternSourceDir");
 		$patternObjects = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($patternSourceDir), \RecursiveIteratorIterator::SELF_FIRST);
 		$patternObjects->setFlags(\FilesystemIterator::SKIP_DOTS);
 


### PR DESCRIPTION
Fixing my own commit from January 2016, when I did not know there was a `patternSourceDir` config option.